### PR TITLE
support ActiveDecorator-0.5.0

### DIFF
--- a/lib/active_decorator/rspec.rb
+++ b/lib/active_decorator/rspec.rb
@@ -12,7 +12,11 @@ module ActiveDecorator
         ApplicationController : ActionController::Base
       controller = Class.new(base_class).new
       controller.request = ActionController::TestRequest.new
-      ActiveDecorator::ViewContext.current = controller.view_context
+      if ActiveDecorator::ViewContext.respond_to?(:current=)
+        ActiveDecorator::ViewContext.current = controller.view_context
+      else
+        ActiveDecorator::ViewContext.push controller.view_context
+      end
 
       self
     end

--- a/spec/decorators/author_decorator_spec.rb
+++ b/spec/decorators/author_decorator_spec.rb
@@ -9,7 +9,7 @@ describe AuthorDecorator do
     its(:reverse_name) { should eq("oob") }
 
     its(:form) {
-      should match %r|^<form class=\"edit_author\" id=\"edit_author_4\" action=\"/authors/4\" accept-charset=\"UTF-8\" method=\"post\">|
+      should match %r|^<form class=\"edit_author\" id=\"edit_author_#{author.id}\" action=\"/authors/#{author.id}\" accept-charset=\"UTF-8\" method=\"post\">|
       should match %r|<input type=\"text\" value=\"boo\" name=\"author\[name\]\" id=\"author_name\" />|
       should match %r|</form>$|
     }

--- a/spec/decorators/author_decorator_spec.rb
+++ b/spec/decorators/author_decorator_spec.rb
@@ -9,8 +9,8 @@ describe AuthorDecorator do
     its(:reverse_name) { should eq("oob") }
 
     its(:form) {
-      should match %r|^<form accept-charset="UTF-8" action="/authors/#{author.id}" class="edit_author" id="edit_author_#{author.id}" method="post">|
-      should match %r|<input id="author_name" name="author\[name\]" type="text" value="boo" />|
+      should match %r|^<form class=\"edit_author\" id=\"edit_author_4\" action=\"/authors/4\" accept-charset=\"UTF-8\" method=\"post\">|
+      should match %r|<input type=\"text\" value=\"boo\" name=\"author\[name\]\" id=\"author_name\" />|
       should match %r|</form>$|
     }
 


### PR DESCRIPTION
ActiveDecorator changed public accessor named ```current=```. I fixed NoMethodError with active_decorator-0.5.0 and form attributes order.