### PR TITLE
Use ApplicationController certainly

### DIFF
--- a/lib/active_decorator/rspec.rb
+++ b/lib/active_decorator/rspec.rb
@@ -8,8 +8,11 @@ module ActiveDecorator
     def self.enable(example)
       example.extend self
 
-      base_class = defined?(ApplicationController) ? \
-        ApplicationController : ActionController::Base
+      base_class = begin
+                     ApplicationController
+                   rescue NameError
+                     ActionController::Base
+                   end
       controller = Class.new(base_class).new
       controller.request = ActionController::TestRequest.new
       if ActiveDecorator::ViewContext.respond_to?(:current=)

--- a/spec/decorators/author_decorator_spec.rb
+++ b/spec/decorators/author_decorator_spec.rb
@@ -17,5 +17,7 @@ describe AuthorDecorator do
     its(:link) { should eq %(<a href="/authors/#{author.id}">boo</a>) }
 
     its(:url) { should eq "http://test.host/authors/#{author.id}" }
+
+    its(:link_if_admin) { should eq %(<a href="/authors/#{author.id}">boo</a>) }
   end
 end

--- a/spec/dummy_app.rb
+++ b/spec/dummy_app.rb
@@ -10,6 +10,7 @@ module DummyApp
     config.session_store :cookie_store, :key => '_dummy_app_session'
     config.active_support.deprecation = :log
     config.eager_load = false
+    config.root = File.join(File.dirname(__FILE__), 'dummy_app')
   end
 end
 DummyApp::Application.initialize!
@@ -37,9 +38,10 @@ module AuthorDecorator
   def url
     author_url(self)
   end
-end
 
-class ApplicationController < ActionController::Base
+  def link_if_admin
+    link if admin?
+  end
 end
 
 class Author < ActiveRecord::Base

--- a/spec/dummy_app/app/controllers/application_controller.rb
+++ b/spec/dummy_app/app/controllers/application_controller.rb
@@ -1,0 +1,7 @@
+class ApplicationController < ActionController::Base
+  helper_method :admin?
+
+  def admin?
+    true
+  end
+end


### PR DESCRIPTION
Sometimes it seems `ApplicationController` isn't used though the file exists.
It may be because `defined?(ApplicationController)` returns `false` before `ApplicationController` is autoloaded.