### PR TITLE
require 'rspec/core' before execute RSpec.configure

### DIFF
--- a/lib/active_decorator/rspec.rb
+++ b/lib/active_decorator/rspec.rb
@@ -1,3 +1,4 @@
+require "rspec/core"
 require "active_decorator"
 require "action_controller"
 require "action_controller/test_case"


### PR DESCRIPTION
to avoid `NameError: uninitialized constant RSpec`